### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM kong:latest
 
 # Install the js-pluginserver
 USER root
-RUN apk add --update nodejs npm python make g++
+RUN apk add --update nodejs npm python3 make g++
 RUN npm install --unsafe -g kong-pdk@0.3.0
 
 ENV term xterm


### PR DESCRIPTION
'python' doesn't work: it should be either 'python2' or 'python3' 