### PR TITLE
apk not found in latest version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong:latest
+FROM kong:3.0.1
 
 # Install the js-pluginserver
 USER root


### PR DESCRIPTION
When running dockerfile with kong:latest tag, as of today we are getting below error. When changing it to specific the then version 3.0.1, it works.

#0 0.359 /bin/sh: 1: apk: not found