### PR TITLE
kong-latest uses ubuntu 22, hence apk changed to apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM kong:latest
 
 # Install the js-pluginserver
 USER root
-RUN apk add --update nodejs npm python3 make g++ && rm -rf /var/cache/apk/*
+RUN apt update
+RUN apt install -y --no-install-recommends nodejs npm python3 make g++ && rm -rf /var/cache/apk/*
 RUN npm install --unsafe -g kong-pdk@0.5.3
 
 ENV term xterm
-RUN apk add --update vim nano
+RUN apt install -y --no-install-recommends vim nano


### PR DESCRIPTION
kong:3.0.1 (the then kong:latest) was using alpine as base image hence apk was working fine.

Now kong:latest is using ubuntu:22.04 as the base image; hence it's broke. This PR aims to fix it.